### PR TITLE
Fixes terraform warning message

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "db_port" {
 }
 
 output "db_identifier" {
-  value = "${aws_db_instance.default.identifier}"
+  value = "${aws_db_instance.default.0.identifier}"
 }
 
 output "db_security_group_id" {


### PR DESCRIPTION
Warning: output "db_identifier": must use splat syntax to access
aws_db_instance.default attribute "identifier", because it has
"count" set